### PR TITLE
Added Bootstrap License

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ Pingbo Zhu
 Shareef Evans
 
 ##License
-This project is not licensed.
+- This project is not licensed.
+- This project uses [Bootstrap](https://getbootstrap.com/), which is licensed under the [MIT License](https://github.com/twbs/bootstrap/blob/main/LICENSE).
+
 
 ##Features
 Add unlimited items and participants to the bill.


### PR DESCRIPTION
**User Story**
AS A developer or user, I WANT to view the bootstrap license in the README file, for legal clarity aspects.

**Acceptance Criteria**
It is done when the README file contains a link to bootstrap's MIT license